### PR TITLE
Fix flask removing the deprecated request.is_xhr

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -314,11 +314,12 @@ def register_request_hooks(app):
             'recovery',
             )
         if request.endpoint not in publicPages:
-            if request.is_xhr:
+            response = redirect(url_for('login'))
+            if request.accept_mimetypes.accept_json \
+                    and not request.accept_mimetypes.accept_html:
                 response = jsonify({'message': 'Not logged in'})
-                response.status_code = 401
-                return response
-            return redirect(url_for('login'))
+            response.status_code = 401
+            return response
 
     @app.before_request
     def get_user():

--- a/app/tests/baseapptest.py
+++ b/app/tests/baseapptest.py
@@ -289,7 +289,7 @@ class BaseAppTestCase(unittest.TestCase):
             path,
             data=json.dumps(data),
             content_type='application/json',
-            headers={'X-Requested-With': 'XMLHttpRequest'}
+            headers={'Accept': 'application/json'},
             )
 
     def patchJSON(self, path, data):
@@ -297,7 +297,7 @@ class BaseAppTestCase(unittest.TestCase):
             path,
             data=json.dumps(data),
             content_type='application/json',
-            headers={'X-Requested-With': 'XMLHttpRequest'}
+            headers={'Accept': 'application/json'},
             )
 
     def doLogin(self, username, password):
@@ -309,7 +309,8 @@ class BaseAppTestCase(unittest.TestCase):
     def doLogout(self, follow_redirects=True):
         return self.client.get(
             '/logout',
-            follow_redirects=follow_redirects
+            follow_redirects=follow_redirects,
+            headers={'Accept': 'application/json'},
             )
 
 if __name__ == '__main__':

--- a/app/tests/test_app.py
+++ b/app/tests/test_app.py
@@ -23,7 +23,7 @@ class AppTestCase(BaseAppTestCase):
 
         rv = self.client.get(
             '/current_user',
-            headers={'X-Requested-With': 'XMLHttpRequest'}
+            headers={'Accept': 'application/json'},
             )
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.mimetype, 'application/json')
@@ -50,7 +50,7 @@ class AppTestCase(BaseAppTestCase):
         for page, expected in list(self.privatePages.items()):
             rv = self.client.get(
                 page,
-                headers={'X-Requested-With': 'XMLHttpRequest'}
+                headers={'Accept': 'application/json'},
                 )
             self.assertEqual(rv.status_code, 401)
 
@@ -85,18 +85,19 @@ class AppTestCase(BaseAppTestCase):
         rv = self.client.get(
             '/current_user',
             follow_redirects=True,
-            headers={'X-Requested-With': 'XMLHttpRequest'}
+            headers={'Accept': 'application/json'},
             )
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.mimetype, 'application/json')
 
         rv = self.doLogout(False)
+        self.assertEqual(rv.get_json(), None)
         self.assertEqual(rv.status_code, 200)
 
         rv = self.client.get(
             '/current_user',
             follow_redirects=True,
-            headers={'X-Requested-With': 'XMLHttpRequest'}
+            headers={'Accept': 'application/json'},
             )
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.get_json(), None)

--- a/app/tests/test_app_character.py
+++ b/app/tests/test_app_character.py
@@ -71,7 +71,7 @@ class AppCharacterTestCase(BaseAppTestCase):
         for page, expected in list(pages.items()):
             rv = self.client.get(
                 page,
-                headers={'X-Requested-With': 'XMLHttpRequest'}
+                headers={'Accept': 'application/json'},
                 )
             self.assertResponse(page, rv, 401)
 

--- a/app/tests/test_app_encounter.py
+++ b/app/tests/test_app_encounter.py
@@ -76,7 +76,7 @@ class AppEncounterTestCase(BaseAppTestCase):
         for page, expected in list(pages.items()):
             rv = self.client.get(
                 page,
-                headers={'X-Requested-With': 'XMLHttpRequest'}
+                headers={'Accept': 'application/json'},
                 )
             self.assertResponse(page, rv, 401)
 

--- a/app/tests/test_app_monster.py
+++ b/app/tests/test_app_monster.py
@@ -88,7 +88,7 @@ class AppMonsterTestCase(BaseAppTestCase):
         for page in self.dmPages:
             rv = self.client.get(
                 page,
-                headers={'X-Requested-With': 'XMLHttpRequest'}
+                headers={'Accept': 'application/json'},
                 )
             self.assertResponse(page, rv, 401)
 

--- a/app/tests/test_app_npc.py
+++ b/app/tests/test_app_npc.py
@@ -79,7 +79,7 @@ class AppNpcTestCase(BaseAppTestCase):
         for page in self.dmPages:
             rv = self.client.get(
                 page,
-                headers={'X-Requested-With': 'XMLHttpRequest'}
+                headers={'Accept': 'application/json'},
                 )
             self.assertResponse(page, rv, 401)
 

--- a/app/tests/test_app_party.py
+++ b/app/tests/test_app_party.py
@@ -73,7 +73,7 @@ class AppPartyTestCase(BaseAppTestCase):
         for page, expected in list(pages.items()):
             rv = self.client.get(
                 page,
-                headers={'X-Requested-With': 'XMLHttpRequest'}
+                headers={'Accept': 'application/json'},
                 )
             self.assertResponse(page, rv, 401)
 

--- a/app/tests/test_app_user.py
+++ b/app/tests/test_app_user.py
@@ -45,7 +45,7 @@ class AppUserTestCase(BaseAppTestCase):
         for page, expected in list(pages.items()):
             rv = self.client.get(
                 page,
-                headers={'X-Requested-With': 'XMLHttpRequest'}
+                headers={'Accept': 'application/json'},
                 )
             self.assertResponse(page, rv, 401)
 

--- a/app/views/base.py
+++ b/app/views/base.py
@@ -422,7 +422,10 @@ def register_paths(app):
         session.pop('user_id', None)
         session.pop('user', None)
         session.pop('party_id', None)
-        return jsonify(None)
+        if request.accept_mimetypes.accept_json \
+                and not request.accept_mimetypes.accept_html:
+            return jsonify(None)
+        return redirect(url_for('home'))
 
 
     @app.route('/privacy-policy', methods=['GET'])

--- a/ui/src/jsx/actions/ListDataActions.jsx
+++ b/ui/src/jsx/actions/ListDataActions.jsx
@@ -25,7 +25,7 @@ ListDataActions.doLogin.listen((credentials, success, failure) => {
         credentials: 'same-origin',
         method: 'POST',
         'headers': {
-            'X-Requested-With': 'XMLHttpRequest',
+            'Accept': 'application/json',
             'Content-Type': 'application/json',
         },
         body: JSON.stringify(credentials)
@@ -74,7 +74,7 @@ ListDataActions.doLogout.listen((callback) => {
     fetch('/logout', {
         credentials: 'same-origin',
         'headers': {
-            'X-Requested-With': 'XMLHttpRequest'
+            'Accept': 'application/json'
         }
     })
     .then(jsonOrBust)

--- a/ui/src/jsx/actions/ObjectDataActions.jsx
+++ b/ui/src/jsx/actions/ObjectDataActions.jsx
@@ -37,7 +37,7 @@ export function ObjectDataActionsFactory(id)
             credentials: 'same-origin',
             method: 'POST',
             'headers': {
-                'X-Requested-With': 'XMLHttpRequest',
+                'Accept': 'application/json',
                 'Content-Type': 'application/json',
             },
             body: JSON.stringify(data)
@@ -72,7 +72,7 @@ export function ObjectDataActionsFactory(id)
             credentials: 'same-origin',
             method: 'PATCH',
             'headers': {
-                'X-Requested-With': 'XMLHttpRequest',
+                'Accept': 'application/json',
                 'Content-Type': 'application/json',
             },
             body: JSON.stringify(data)
@@ -107,7 +107,7 @@ export function ObjectDataActionsFactory(id)
             credentials: 'same-origin',
             method: 'GET',
             'headers': {
-                'X-Requested-With': 'XMLHttpRequest'
+                'Accept': 'application/json'
             }
         })
         .then(jsonOrBust)
@@ -144,7 +144,7 @@ export function ObjectDataActionsFactory(id)
             credentials: 'same-origin',
             method: 'PATCH',
             'headers': {
-                'X-Requested-With': 'XMLHttpRequest'
+                'Accept': 'application/json'
             }
         })
         .then(jsonOrBust)
@@ -181,7 +181,7 @@ export function ObjectDataActionsFactory(id)
             credentials: 'same-origin',
             method: 'DELETE',
             'headers': {
-                'X-Requested-With': 'XMLHttpRequest'
+                'Accept': 'application/json'
             }
         })
         .then(jsonOrBust)
@@ -215,7 +215,7 @@ export function ObjectDataActionsFactory(id)
                 credentials: 'same-origin',
                 method: 'POST',
                 'headers': {
-                    'X-Requested-With': 'XMLHttpRequest',
+                    'Accept': 'application/json',
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify(data)

--- a/ui/src/jsx/actions/ReportingActions.jsx
+++ b/ui/src/jsx/actions/ReportingActions.jsx
@@ -23,7 +23,7 @@ ReportingActions.getMessages.listen(debounce(() => {
         credentials: 'same-origin',
         method: 'GET',
         'headers': {
-            'X-Requested-With': 'XMLHttpRequest',
+            'Accept': 'application/json',
             'Content-Type': 'application/json',
         },
     })
@@ -43,7 +43,7 @@ ReportingActions.reportError.listen((error, info) => {
         credentials: 'same-origin',
         method: 'POST',
         'headers': {
-            'X-Requested-With': 'XMLHttpRequest',
+            'Accept': 'application/json',
             'Content-Type': 'application/json',
         },
         body: JSON.stringify({error, info})

--- a/ui/src/jsx/components/CampaignLinks.jsx
+++ b/ui/src/jsx/components/CampaignLinks.jsx
@@ -25,7 +25,7 @@ export class CampaignLinks extends React.Component
             method: "POST",
             credentials: 'same-origin',
             'headers': {
-                'X-Requested-With': 'XMLHttpRequest'
+                'Accept': 'application/json'
             }
         })
         .then((response) => response.json())
@@ -41,7 +41,7 @@ export class CampaignLinks extends React.Component
             method: "POST",
             credentials: 'same-origin',
             'headers': {
-                'X-Requested-With': 'XMLHttpRequest'
+                'Accept': 'application/json'
             }
         })
         .then((response) => response.json())

--- a/ui/src/jsx/components/CharacterConfig/actions/CharacterEditorActions.jsx
+++ b/ui/src/jsx/components/CharacterConfig/actions/CharacterEditorActions.jsx
@@ -23,7 +23,7 @@ function getCharacter(action, id) {
         credentials: 'same-origin',
         method: 'GET',
         'headers': {
-            'X-Requested-With': 'XMLHttpRequest'
+            'Accept': 'application/json'
         }
     })
     .then(response => response.json())
@@ -57,7 +57,7 @@ const saveCharacter = (
         credentials: 'same-origin',
         method,
         'headers': {
-            'X-Requested-With': 'XMLHttpRequest',
+            'Accept': 'application/json',
             'Content-Type': 'application/json',
         },
         body: JSON.stringify(data)

--- a/ui/src/jsx/components/PartyLinks.jsx
+++ b/ui/src/jsx/components/PartyLinks.jsx
@@ -20,7 +20,7 @@ export class PartyLinks extends BaseLinkGroup
             method: "POST",
             credentials: 'same-origin',
             'headers': {
-                'X-Requested-With': 'XMLHttpRequest'
+                'Accept': 'application/json'
             }
         })
         .then((response) => response.json())
@@ -36,7 +36,7 @@ export class PartyLinks extends BaseLinkGroup
         method: "POST",
             credentials: 'same-origin',
             'headers': {
-                'X-Requested-With': 'XMLHttpRequest'
+                'Accept': 'application/json'
             }
         })
         .then((response) => response.json())

--- a/ui/src/jsx/stores/ListDataStore.jsx
+++ b/ui/src/jsx/stores/ListDataStore.jsx
@@ -39,7 +39,7 @@ class ListDataStore extends Reflux.Store
         fetch(path, {
             credentials: 'same-origin',
             'headers': {
-                'X-Requested-With': 'XMLHttpRequest',
+                'Accept': 'application/json',
             }
         })
         .then((response) => {

--- a/ui/src/jsx/stores/ObjectDataStore.jsx
+++ b/ui/src/jsx/stores/ObjectDataStore.jsx
@@ -95,7 +95,7 @@ export function ObjectDataStoreFactory(id, listenables = null)
                 credentials: 'same-origin',
                 method: 'GET',
                 'headers': {
-                    'X-Requested-With': 'XMLHttpRequest'
+                    'Accept': 'application/json'
                 }
             })
             .then((response) => {
@@ -214,7 +214,7 @@ export function ObjectDataStoreFactory(id, listenables = null)
                 credentials: 'same-origin',
                 method: 'GET',
                 'headers': {
-                    'X-Requested-With': 'XMLHttpRequest'
+                    'Accept': 'application/json'
                 }
             })
             .then((response) => {

--- a/ui/src/jsx/views/EncounterView.jsx
+++ b/ui/src/jsx/views/EncounterView.jsx
@@ -189,7 +189,7 @@ export class EncounterView extends React.Component
                 method: "POST",
                 credentials: 'same-origin',
                 headers: {
-                    'X-Requested-With': 'XMLHttpRequest'
+                    'Accept': 'application/json'
             }
         })
             .then(response => response.json())

--- a/ui/tests/components/AdventureLeagueLogLinks.react-test.jsx
+++ b/ui/tests/components/AdventureLeagueLogLinks.react-test.jsx
@@ -170,7 +170,7 @@ describe('Component: AdventureLeagueLogLinks', () => {
                     credentials: 'same-origin',
                     method: 'DELETE',
                     'headers': {
-                        'X-Requested-With': 'XMLHttpRequest'
+                        'Accept': 'application/json'
                     }
                 }
             );
@@ -246,7 +246,7 @@ describe('Component: AdventureLeagueLogLinks', () => {
                     credentials: 'same-origin',
                     method: 'PATCH',
                     'headers': {
-                        'X-Requested-With': 'XMLHttpRequest'
+                        'Accept': 'application/json'
                     }
                 }
             );

--- a/ui/tests/components/CampaignLinks.react-test.jsx
+++ b/ui/tests/components/CampaignLinks.react-test.jsx
@@ -107,7 +107,7 @@ describe('Component: CampaignLinks', () => {
                 credentials: 'same-origin',
                 method: 'POST',
                 'headers': {
-                    'X-Requested-With': 'XMLHttpRequest'
+                    'Accept': 'application/json'
                 }
             }
         );
@@ -150,7 +150,7 @@ describe('Component: CampaignLinks', () => {
                 credentials: 'same-origin',
                 method: 'POST',
                 'headers': {
-                    'X-Requested-With': 'XMLHttpRequest'
+                    'Accept': 'application/json'
                 }
             }
         );

--- a/ui/tests/components/CharacterLinks.react-test.jsx
+++ b/ui/tests/components/CharacterLinks.react-test.jsx
@@ -171,7 +171,7 @@ describe('Component: CharacterLinks', () => {
                 credentials: 'same-origin',
                 method: 'GET',
                 'headers': {
-                    'X-Requested-With': 'XMLHttpRequest'
+                    'Accept': 'application/json'
                 }
             }
         );
@@ -211,7 +211,7 @@ describe('Component: CharacterLinks', () => {
                 credentials: 'same-origin',
                 method: 'DELETE',
                 'headers': {
-                    'X-Requested-With': 'XMLHttpRequest'
+                    'Accept': 'application/json'
                 }
             }
         );

--- a/ui/tests/components/MonsterLinks.react-test.jsx
+++ b/ui/tests/components/MonsterLinks.react-test.jsx
@@ -111,7 +111,7 @@ describe('Component: MonsterLinks', () => {
                 credentials: 'same-origin',
                 method: 'GET',
                 'headers': {
-                    'X-Requested-With': 'XMLHttpRequest'
+                    'Accept': 'application/json'
                 }
             }
         );

--- a/ui/tests/components/PartyLinks.react-test.jsx
+++ b/ui/tests/components/PartyLinks.react-test.jsx
@@ -174,7 +174,7 @@ describe('Component: PartyLinks', () => {
                 credentials: 'same-origin',
                 method: 'POST',
                 'headers': {
-                    'X-Requested-With': 'XMLHttpRequest'
+                    'Accept': 'application/json'
                 }
             }
         );
@@ -217,7 +217,7 @@ describe('Component: PartyLinks', () => {
                 credentials: 'same-origin',
                 method: 'POST',
                 'headers': {
-                    'X-Requested-With': 'XMLHttpRequest'
+                    'Accept': 'application/json'
                 }
             }
         );


### PR DESCRIPTION
Flask's `request.is_xhr` has been removed. This request distinction is now covered using the `Accept: application/json` header.