### PR TITLE
Bump python build after crypto package update

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -87,9 +87,8 @@ steps:
              "backups/machine.staging.db.$(date '+%Y%m%d')"
 
   - name: tags
-    image: alpine
+    image: plugins/git
     commands:
-      - apk add git
       - git fetch --tags
       - echo 'GIT_TAG='$(git describe --tags) >> .env
 
@@ -237,6 +236,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 11353ed1188155765dc6581c650c7489ac5d45831506704962dcc4a3289d148d
+hmac: f3f929c5da580f71fe19201fc5871fe3d7f65a3e6a4a7b10cf314a51df4ecbcd
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,7 @@ steps:
       - apt-get update
       - mkdir -p /usr/share/man/man1/
       - touch /usr/share/man/man1/rmid.1.gz.dpkg-tmp
-      - apt-get install -y pdftk build-essential python3-dev libffi-dev libssl-dev
+      - apt-get install -y pdftk build-essential python3-dev libffi-dev libssl-dev cargo rustc
       - pip install -r requirements.txt
       - python app/tests/run_tests.py
 
@@ -237,6 +237,6 @@ volumes:
 
 ---
 kind: signature
-hmac: 69f11f84f90e7819062fd24141ceaf6efc83d210ad9a16f7092be44d0f3e7b58
+hmac: 11353ed1188155765dc6581c650c7489ac5d45831506704962dcc4a3289d148d
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN apt-get update \
         python3-dev \
         libffi-dev \
         libssl-dev \
+        cargo \
+        rustc \
     && pip install \
         -r ./requirements.txt \
     && apt-get purge -y --auto-remove \

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
         python3-dev \
         libffi-dev \
         libssl-dev \
+        cargo \
+        rustc \
     && pip install \
         -r ./requirements.txt \
     && apt-get purge -y --auto-remove \


### PR DESCRIPTION
Fixed the failing python part of the test and build pipeline after bumping the `crypto` package version.